### PR TITLE
add option -m to reduce number of available codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ If you compile the dependencies from source, make sure that libpt and libopal ar
 -f <file> --file <file>         the name of played sound file
 -g <addr> --gatekeeper <addr>   gatekeeper to use
 -w <addr> --gateway <addr>      gateway to use
+-m <codec> -mediaformat <codec> one or more codecs to use, separated by semicolon; wildcards are supported (e.g. -m "G.711*;G.722*")
 </pre>
 <p>
 <code>-l</code> or <code>-p</code> without <code>-x</code> assumes answer mode. Additional <code>-r</code> forces caller id checking. <code>-r</code> without <code>-l</code>, <code>-p</code> or <code>-x</code> assumes call mode.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,6 @@ static std::string stringify(const PString &broken) {
 
 static void print_help() {
     cerr << "sipcmd options: " << endl
-        << "-T <timeout> --dialtimeout <timeout>  dial timeout in seconds" << endl
         << "-u <name>    --user <name>            username (required)" << endl
         << "-c <passw>   --password <passw>       password for registration" << endl
         << "-l <addr>    --localaddress <addr>    local address to listen on" << endl 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,19 +37,21 @@ static std::string stringify(const PString &broken) {
 
 static void print_help() {
     cerr << "sipcmd options: " << endl
-        << "-u <name>   --user <name>         username (required)" << endl
-        << "-c <passw>  --password <passw>    password for registration" << endl
-        << "-a <name>   --alias <name>        username alias" << endl 
-        << "-l <addr>   --localaddress <addr> local address to listen on" << endl 
-        << "-o <file>   --opallog <file>      enable extra opal library logging to file" << endl
-        << "-p <port>   --listenport <port>   the port to listen on" << endl 
-        << "-P <proto>  -- protocol <proto>   sip/h323/rtp (required)" << endl 
-        << "-r <nmbr>   --remoteparty <nmbr>  the party to call to" << endl 
-        << "-x <prog>   --execute <prog>      program to follow" << endl  
-        << "-d <prfx>   --audio-prefix <prfx> recorded audio filename prefix" << endl 
-        << "-f <file>   --file <file>         the name of played sound file" << endl 
-        << "-g <addr>   --gatekeeper <addr>   gatekeeper to use" << endl 
-        << "-w <addr>   --gateway <addr>      gateway to use" << endl << endl;
+        << "-T <timeout> --dialtimeout <timeout>  dial timeout in seconds" << endl
+        << "-u <name>    --user <name>            username (required)" << endl
+        << "-c <passw>   --password <passw>       password for registration" << endl
+        << "-l <addr>    --localaddress <addr>    local address to listen on" << endl 
+        << "-o <file>    --opallog <file>         enable extra opal library logging to file" << endl
+        << "-p <port>    --listenport <port>      the port to listen on" << endl 
+        << "-P <proto>   -- protocol <proto>      sip/h323/rtp (required)" << endl 
+        << "-r <nmbr>    --remoteparty <nmbr>     the party to call to" << endl 
+        << "-x <prog>    --execute <prog>         program to follow" << endl  
+        << "-d <prfx>    --audio-prefix <prfx>    recorded audio filename prefix" << endl 
+        << "-f <file>    --file <file>            the name of played sound file" << endl 
+        << "-g <addr>    --gatekeeper <addr>      gatekeeper to use" << endl 
+        << "-w <addr>    --gateway <addr>         gateway to use" << endl 
+        << "-a <name>    --alias <name>           username alias" << endl << endl
+        << "-m <codec>   --mediaformat <codec>   select codec" << endl << endl;
 
     cerr << "The EBNF definition of the program syntax:" << endl
         << "<prog>  := cmd ';' <prog> | " << endl
@@ -240,7 +242,8 @@ bool LocalEndPoint::OnWriteMediaData(
 }
 
 Manager::Manager() : localep(NULL), sipep(NULL), h323ep(NULL), 
-  listenmode(false), listenerup(false), pauseBeforeDialing(false)
+  listenmode(false), listenerup(false), pauseBeforeDialing(false),
+  mediaFilter("*")
 {
   std::cout << __func__  << std::endl;
 }
@@ -276,6 +279,11 @@ void Manager::Main(PArgList &args)
     if (args.HasOption('x')) {
         
         cmdseq = args.GetOptionString('x');
+    }
+
+    if (args.HasOption('m')) {
+        
+        mediaFilter = stringify(args.GetOptionString('m'));
     }
 
     // Parse command sequence
@@ -322,6 +330,7 @@ bool Manager::Init(PArgList &args)
             "g-gatekeeper:"
             "w-gateway:"
             "h-help:"
+            "m-mediaformat:"
             );
 
 
@@ -672,6 +681,17 @@ OpalConnection::AnswerCallResponse Manager::OnAnswerCall(
 void Manager::OnClosedMediaStream (const OpalMediaStream &stream)
 {
     std::cout << __func__ << std::endl;
+}
+
+        
+void Manager::AdjustMediaFormats(
+  bool local,                         ///<  Media formats a local ones to be presented to remote
+  const OpalConnection & connection,  ///<  Connection that is about to use formats
+  OpalMediaFormatList & mediaFormats  ///<  Media formats to use
+) const
+{
+     PStringArray mask("!"+mediaFilter);
+     mediaFormats.Remove(mask);
 }
 
 bool Manager::OnIncomingConnection(OpalConnection &connection, unsigned opts,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -689,8 +689,26 @@ void Manager::AdjustMediaFormats(
   OpalMediaFormatList & mediaFormats  ///<  Media formats to use
 ) const
 {
-     PStringArray mask("!"+mediaFilter);
-     mediaFormats.Remove(mask);
+    std::cout << "available codes" << std::endl;
+    for (OpalMediaFormatList::iterator it1 = mediaFormats.begin(); it1!=mediaFormats.end(); it1++)
+    {
+        std::cout << "  " << it1->GetName() << std::endl;
+    }
+     
+    PStringArray mask;
+    std::string s;   
+    istringstream ss(mediaFilter);
+    while (getline(ss, s, ';')) 
+    {
+        mask.AppendString("!"+s);
+    }
+    mediaFormats.Remove(mask);
+    
+    std::cout << "used codes" << std::endl;
+    for (OpalMediaFormatList::iterator it2 = mediaFormats.begin(); it2!=mediaFormats.end(); it2++)
+    {
+        std::cout << "  " << it2->GetName() << std::endl;
+    }
 }
 
 bool Manager::OnIncomingConnection(OpalConnection &connection, unsigned opts,

--- a/src/main.h
+++ b/src/main.h
@@ -134,6 +134,12 @@ class Manager : public OpalManager
 
         virtual void OnClosedMediaStream (
                 const OpalMediaStream &stream);
+        
+        virtual void AdjustMediaFormats(
+          bool local,                         ///<  Media formats a local ones to be presented to remote
+          const OpalConnection & connection,  ///<  Connection that is about to use formats
+          OpalMediaFormatList & mediaFormats  ///<  Media formats to use
+        ) const;
 
         // Connection Management
         virtual bool OnIncomingConnection(
@@ -175,6 +181,7 @@ class Manager : public OpalManager
         bool listenmode;
         bool listenerup;
         bool pauseBeforeDialing;
+        std::string mediaFilter;
 
         Manager(const Manager&);
         Manager operator=(Manager&);


### PR DESCRIPTION
When connecting sipcmd with Fritz!Box firmware 6.80 it is not working anymore. A large number of available codecs will lead to a "parser memory problem" and connection will be aborted by remote.
To save memory (and allow parser to work with the available memory) one can preselect the available codecs. Wildcards are supported (e.g. "G.711*"). All codecs not fitting to this filter will be removed before a connection is made.
Maybe this also solves issue #40 in some way.