### PR TITLE
fix: use archive repo for debian stretch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,16 @@
 FROM debian:stretch-slim
 
-
 LABEL Description="SIP" Vendor="Daniel Drexlmaier" Version="1.6" maintainer="dd@dbe.academy"
 ENV DEBIAN_FRONTEND noninteractive
 ENV LOCALE en_EN.UTF-8
 
+RUN echo "deb http://archive.debian.org/debian/ stretch contrib main non-free" > /etc/apt/sources.list
+RUN apt-get update && apt-get -y upgrade &&  apt-get install --allow-downgrades -y git libopal-dev libpt-dev libsdl1.2-dev libpulse-dev libcaca-dev libglib2.0-dev libslang2-dev zlib1g-dev zlib1g=1:1.2.8.dfsg-5
 
-RUN apt-get update && apt-get -y upgrade && apt-get install -y vim git libopal-dev libpt-dev
+
 RUN git clone https://github.com/tmakkonen/sipcmd.git && \
 cd sipcmd && \
-apt install -y make g++ 
+apt install -y make g++
 
 #COPY alert1.wav /sipcmd/alert1.wav
 #COPY alert2.wav /sipcmd/alert2.wav

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,5 +1,5 @@
 docker stop sip
-docker rm sip  
+docker rm sip
 docker build -t sip .
 docker run --cap-add SYS_NICE  --security-opt seccomp:unconfined -p 5060:5060 --name="sip"  -d sip
 docker exec -it sip bash


### PR DESCRIPTION
Debian 9 is deprecated. apt wont work properly anymore, we need to use archive repo to keep the container working!